### PR TITLE
Document GPUI key-context stacking limitation (#23)

### DIFF
--- a/docs/execplans/0-1-3-key-context-system.md
+++ b/docs/execplans/0-1-3-key-context-system.md
@@ -51,7 +51,10 @@ Future work may explore nested elements with different contexts if mode-
 specific shortcut scoping becomes necessary.
 
 **Architecture Reference**: This limitation is documented as an architectural
-constraint in section 7.2.1 of `docs/gauss-architecture-design.md`.
+constraint in [section 7.2.1][arch-key-context-limitation] of the architecture
+document.
+
+[arch-key-context-limitation]: ../gauss-architecture-design.md#721-gpui-key-context-limitation-and-workaround
 
 ### GPUI Action Bridge Pattern
 

--- a/docs/gauss-architecture-design.md
+++ b/docs/gauss-architecture-design.md
@@ -516,9 +516,9 @@ all known contexts at registration time. When a binding specifies
 across all context variants (DrawMode, ManipulateMode, etc.). The view layer
 currently sets only `KeyContext::Global` as the GPUI context.
 
-**Implementation Reference**: See `src/ui/action_bridge/mod.rs` lines 166–212
-for the binding expansion logic in `CollectedBindings::from_default_bindings()`
-and `add_binding_for_contexts()`.
+**Implementation Reference**: See `CollectedBindings::from_default_bindings()`
+and `add_binding_for_contexts()` in `src/ui/action_bridge/mod.rs` for the
+binding expansion logic.
 
 **Architectural Risk**: Mode-specific bindings are not enforced by GPUI's
 context isolation. The system relies on runtime mode checks within action


### PR DESCRIPTION
## Summary

- Add section 7.2.1 to architecture document documenting the GPUI key-context
  stacking limitation and the action_bridge workaround
- Update execution plan with cross-reference to the new architecture section

## Test plan

- [x] `make markdownlint` passes
- [x] Documentation accurately describes the limitation discovered during
  implementation

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the current GPUI key-context limitation and its workaround, and cross-reference this architectural constraint from the key-context execution plan.

Documentation:
- Add a new architecture section describing GPUI key-context replacement behavior, the action_bridge duplication workaround, associated risks, and future considerations.
- Update the key-context system execution plan to reference the new architectural documentation section for this limitation.