### PR TITLE
Add Dependabot automerge workflow call

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,14 @@
+name: Dependabot Automerge
+
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-automerge:
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@235d2d07b9a321364a742310873f6732d7228e72


### PR DESCRIPTION
## Summary
- Adds a Dependabot Automerge workflow that delegates to a shared, reusable workflow to automatically merge Dependabot pull requests.

## Changes
### Workflow Additions
- **.github/workflows/dependabot-automerge.yml**: New workflow file that invokes the shared automerge workflow
- **Triggering events**:
  - On pull_request: types [opened, synchronize, reopened]
  - workflow_dispatch: manual trigger
- **Permissions**:
  - contents: write
  - pull-requests: write
- **Reusable workflow**:
  - Uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@235d2d07b9a321364a742310873f6732d7228e72

### Rationale
- Enables automated merging of Dependabot PRs per repository policy, reducing manual maintenance and keeping dependencies up to date.

## Test plan
- [x] Ensure new workflow file is added to the repo
- [x] Trigger workflow manually via workflow_dispatch to verify invocation
- [x] Create/modify a Dependabot PR and verify automerge logic runs and merges PRs that pass checks
- [x] Confirm Dependabot PRs with failing checks remain unmerged



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a8449213-d574-45a6-a2a7-fd9c84d7d211

## Summary by Sourcery

CI:
- Introduce a Dependabot automerge workflow triggered on pull request events and manual dispatch with write permissions for contents and pull requests.