### PR TITLE
Wire the CodeScene coverage upload into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,14 @@ jobs:
       WHITAKER_INSTALLER_REV: f768c2e53c47df13658af1168a67851d388750bf
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
       - name: Setup mold linker
         if: runner.os == 'Linux'
         uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878
       - name: Setup Rust
         uses: >-
-          leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -49,18 +51,19 @@ jobs:
         run: make lint
       - name: Test and Measure Coverage
         uses: >-
-          leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+          leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           features: test-support
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: >-
-          leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 75146 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro's projects hit the byte-identical
+      # error). Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the
+      # gate is confirmed to resolve, or once CodeScene confirms the
+      # project's coverage gate is enabled.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,55 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests will run
+# the changed-line gate (`cs-coverage check`) in ci.yml once CodeScene
+# enables the coverage-gates configuration for this project (see the
+# comment in ci.yml). This workflow also advances the coverage ratchet
+# baseline: caches saved on main are readable by every pull-request
+# run, so the baseline written here is the one PR ratchet checks
+# compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+      WHITAKER_INSTALLER_REV: f768c2e53c47df13658af1168a67851d388750bf
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Setup mold linker
+        if: runner.os == 'Linux'
+        uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878
+      - name: Setup Rust
+        uses: >-
+          leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libxcb1-dev libxkbcommon-dev \
+            libxkbcommon-x11-dev
+      - name: Generate coverage
+        uses: >-
+          leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          features: test-support
+          output-path: lcov.info
+          format: lcov
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: >-
+          leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1b2711ce239338df192ed58809be6a145736b878
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Bump every `leynos/shared-actions/...` pin in this repo to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (shared-actions#334,
  which adds the coverage `mode: check` gate).
- Enable the coverage ratchet on `generate-coverage` in `ci.yml`.
- Add `.github/workflows/coverage-main.yml`, which uploads coverage
  to CodeScene (`mode: upload`, the default) on every push to
  `main` and writes the ratchet baseline that PR runs compare
  against.
- Remove the PR-side `upload-codescene-coverage` step from
  `ci.yml`: it previously ran with no `mode` set, which defaults
  to `upload`, and CodeScene only accepts uploads for analysed
  branches (`main`) — the step would fail every PR run now that the
  guarding secret is set. The `mode: check` changed-line gate is
  deliberately deferred; a comment in `ci.yml` explains why and what
  unblocks it.
- Set `CS_ACCESS_TOKEN` in both the Actions and Dependabot secret
  stores (repo: leynos/gauss).

## Why the PR-side gate is deferred

CodeScene project [75146](https://codescene.io/projects/75146) has no
coverage-gates configuration yet. Running `cs-coverage check` against
it fails unconditionally with:

```
HTTP call succeeded, but the received project-config isn't valid.
Lacks the gates configuration.
```

This is a CodeScene-side per-project toggle, not a CI defect — the
byte-identical error was already found on ddlint
([#287](https://github.com/leynos/ddlint/pull/287)) and chutoro
(project 71838). Until CodeScene enables the gate for this project (or
confirms it activates automatically once `coverage-main.yml` has
uploaded from main), only the upload half of the pattern is wired in
here.

## Rollup note for reviewers

This repo's required check is `build-test` only; the CodeScene
`Code Coverage` check (from the `codescene-access` GitHub App) is
not part of the branch ruleset — it blocks merges only through GitHub's
overall status rollup if it posts and times out. Today CodeScene does
not post a `Code Coverage` check on this repo at all (only the
existing `Code Health Review` check), so this PR carries no risk of
jamming the rollup; it starts feeding CodeScene real coverage data so
the coverage check (and eventually the PR gate) can be turned on
project-side.

## Review walkthrough

- [.github/workflows/ci.yml](https://github.com/leynos/gauss/blob/codescene-coverage-gate/.github/workflows/ci.yml) —
  pin bump, `fetch-depth: 0`, ratchet enabled, PR upload step removed
  and replaced with an explanatory comment.
- [.github/workflows/coverage-main.yml](https://github.com/leynos/gauss/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml) —
  new workflow; generates and uploads coverage from `main` pushes.
- [.github/workflows/dependabot-automerge.yml](https://github.com/leynos/gauss/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml) —
  pin bump only, keeping a single repo-wide shared-actions pin.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(f))"` over all three
  changed/added workflow files.
- No workflow-contract tests exist in this repo to update.
- Full local build/test suite intentionally not run (shared machine);
  CI will exercise the changed workflow.
