### PR TITLE
Migrate remaining GPUI i18n tests to BDD (#120)

### DIFF
--- a/crates/gauss-core/src/model/history/tests/mod.rs
+++ b/crates/gauss-core/src/model/history/tests/mod.rs
@@ -43,6 +43,25 @@ fn doc_with_one_shape(sample_shape: Shape) -> (Document, ShapeId) {
     (doc, id)
 }
 
+/// Apply `cmd` to `doc`, returning the command alongside its inverse.
+///
+/// `operation` names the calling helper so a failure identifies which command
+/// could not be applied. This is the single panic boundary for these helpers:
+/// `.expect()` is disallowed outside test-attributed functions (whitaker
+/// `no_expect_outside_tests`), so the `Err` variant is handled explicitly here
+/// rather than at each call site.
+fn apply_command(
+    doc: &mut Document,
+    cmd: Command,
+    operation: &str,
+) -> (Command, crate::model::command::CommandInverse) {
+    let inverse = match cmd.apply(doc) {
+        Ok(inverse) => inverse,
+        Err(error) => panic!("{operation} should succeed: {error:?}"),
+    };
+    (cmd, inverse)
+}
+
 /// Build and apply a `MoveShapes` command, returning the command and inverse.
 fn apply_move(
     doc: &mut Document,
@@ -56,13 +75,7 @@ fn apply_move(
             delta: Vec2::new(dx, dy),
         }],
     };
-    // `.expect()` is disallowed outside test-attributed functions (whitaker
-    // `no_expect_outside_tests`); handle the Err explicitly instead.
-    let inverse = match cmd.apply(doc) {
-        Ok(inverse) => inverse,
-        Err(error) => panic!("apply_move should succeed: {error:?}"),
-    };
-    (cmd, inverse)
+    apply_command(doc, cmd, "apply_move")
 }
 
 /// Build and apply an `InsertShape` command, returning the command and inverse.
@@ -74,13 +87,7 @@ fn apply_insert(
     let cmd = Command::InsertShape {
         insertion: crate::model::ShapeInsertion { index, shape },
     };
-    // `.expect()` is disallowed outside test-attributed functions (whitaker
-    // `no_expect_outside_tests`); handle the Err explicitly instead.
-    let inverse = match cmd.apply(doc) {
-        Ok(inverse) => inverse,
-        Err(error) => panic!("apply_insert should succeed: {error:?}"),
-    };
-    (cmd, inverse)
+    apply_command(doc, cmd, "apply_insert")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/gauss-core/src/model/history/tests/mod.rs
+++ b/crates/gauss-core/src/model/history/tests/mod.rs
@@ -56,7 +56,12 @@ fn apply_move(
             delta: Vec2::new(dx, dy),
         }],
     };
-    let inverse = cmd.apply(doc).expect("apply_move should succeed");
+    // `.expect()` is disallowed outside test-attributed functions (whitaker
+    // `no_expect_outside_tests`); handle the Err explicitly instead.
+    let inverse = match cmd.apply(doc) {
+        Ok(inverse) => inverse,
+        Err(error) => panic!("apply_move should succeed: {error:?}"),
+    };
     (cmd, inverse)
 }
 
@@ -69,7 +74,12 @@ fn apply_insert(
     let cmd = Command::InsertShape {
         insertion: crate::model::ShapeInsertion { index, shape },
     };
-    let inverse = cmd.apply(doc).expect("apply_insert should succeed");
+    // `.expect()` is disallowed outside test-attributed functions (whitaker
+    // `no_expect_outside_tests`); handle the Err explicitly instead.
+    let inverse = match cmd.apply(doc) {
+        Ok(inverse) => inverse,
+        Err(error) => panic!("apply_insert should succeed: {error:?}"),
+    };
     (cmd, inverse)
 }
 

--- a/crates/gauss-svg/src/svg/export/tests/mod.rs
+++ b/crates/gauss-svg/src/svg/export/tests/mod.rs
@@ -172,8 +172,13 @@ fn create_line_shape_for_export(
 
 /// Verify SVG root element structure (without namespace checks).
 fn assert_svg_root_element(svg: &str, expected_width: f32, expected_height: f32) {
-    let document =
-        roxmltree::Document::parse(svg).expect("exported SVG should always be valid XML");
+    // `.expect()` is disallowed outside test-attributed functions (whitaker
+    // `no_expect_outside_tests`); handle the Err explicitly, matching the
+    // panic-in-test idiom used elsewhere in this suite.
+    let document = match roxmltree::Document::parse(svg) {
+        Ok(document) => document,
+        Err(error) => panic!("exported SVG should always be valid XML: {error:?}"),
+    };
     let root = document.root_element();
     assert!(svg.contains(r#"<svg xmlns="http://www.w3.org/2000/svg""#));
     assert!(svg.contains(&format!(
@@ -184,8 +189,13 @@ fn assert_svg_root_element(svg: &str, expected_width: f32, expected_height: f32)
 
 /// Verify Gauss metadata namespace declaration on root.
 fn assert_gauss_namespace_declared(svg: &str) {
-    let document =
-        roxmltree::Document::parse(svg).expect("exported SVG should always be valid XML");
+    // `.expect()` is disallowed outside test-attributed functions (whitaker
+    // `no_expect_outside_tests`); handle the Err explicitly, matching the
+    // panic-in-test idiom used elsewhere in this suite.
+    let document = match roxmltree::Document::parse(svg) {
+        Ok(document) => document,
+        Err(error) => panic!("exported SVG should always be valid XML: {error:?}"),
+    };
     let root = document.root_element();
     let metadata_namespace =
         format!(r#"xmlns:{GAUSS_METADATA_PREFIX}="{GAUSS_METADATA_NAMESPACE}""#);

--- a/src/ui/phase0_shell/a11y_service/tests/i18n_tests.rs
+++ b/src/ui/phase0_shell/a11y_service/tests/i18n_tests.rs
@@ -118,14 +118,19 @@ fn fr_locale_snapshot(localizer: Localizer) -> A11ySnapshot {
 }
 
 fn get_status_label(snapshot: &A11ySnapshot) -> String {
-    let (nodes, _) = build_node_map(snapshot).expect("node map build should succeed");
-    let status_node = nodes
-        .get(&STATUS_NODE_ID)
-        .expect("expected node map to contain status node");
-    status_node
-        .label()
-        .expect("status node should have a label")
-        .to_owned()
+    // `.expect()` is disallowed outside test-attributed functions (whitaker
+    // `no_expect_outside_tests`); handle each failure explicitly instead.
+    let (nodes, _) = match build_node_map(snapshot) {
+        Ok(result) => result,
+        Err(error) => panic!("node map build should succeed: {error:?}"),
+    };
+    let Some(status_node) = nodes.get(&STATUS_NODE_ID) else {
+        panic!("expected node map to contain status node");
+    };
+    let Some(label) = status_node.label() else {
+        panic!("status node should have a label");
+    };
+    label.to_owned()
 }
 
 #[rstest]

--- a/src/ui/phase0_shell/a11y_service/tests/mod.rs
+++ b/src/ui/phase0_shell/a11y_service/tests/mod.rs
@@ -56,9 +56,11 @@ fn snapshot_with_state(
 
 fn routed_service() -> A11yService {
     let mut service = A11yService::new();
-    service
-        .sync_from_shell_like(snapshot(&[], &[]))
-        .expect("baseline accessibility snapshot should sync");
+    // `.expect()` is disallowed outside test-attributed functions (whitaker
+    // `no_expect_outside_tests`); handle the Err explicitly instead.
+    if let Err(error) = service.sync_from_shell_like(snapshot(&[], &[])) {
+        panic!("baseline accessibility snapshot should sync: {error:?}");
+    }
     service
 }
 

--- a/tests/features/gpui_i18n_status.feature
+++ b/tests/features/gpui_i18n_status.feature
@@ -2,28 +2,28 @@ Feature: Localized Phase 0 shell status
 
   Scenario: Default English catalogue localizes the mode status
     Given a fresh Phase 0 shell using the default English catalogue
-    Then the mode status shows the tool label "Draw"
-    And the mode status shows the edge label "Line"
+    Then the mode status shows the tool label Draw
+    And the mode status shows the edge label Line
 
   Scenario: Injected French catalogue localizes the mode status
     Given a fresh Phase 0 shell using the test French catalogue
-    Then the mode status shows the tool label "Dessiner"
-    And the mode status shows the edge label "Ligne"
+    Then the mode status shows the tool label Dessiner
+    And the mode status shows the edge label Ligne
 
   Scenario: Switching locale updates the mode status
     Given a fresh Phase 0 shell with English and French catalogues
-    Then the mode status shows the tool label "Draw"
+    Then the mode status shows the tool label Draw
     When the shell locale is switched to French
-    Then the mode status shows the tool label "Dessiner"
-    And the mode status shows the edge label "Ligne"
+    Then the mode status shows the tool label Dessiner
+    And the mode status shows the edge label Ligne
 
   Scenario: Missing French message falls back to the default locale
     Given a fresh Phase 0 shell with a partial French catalogue
-    Then the mode status shows the tool label "Dessiner"
+    Then the mode status shows the tool label Dessiner
     And the mode status shows the fallback edge label
 
   Scenario: Manipulate mode omits the edge mode from the status
     Given a fresh Phase 0 shell using the test French catalogue
     When the shell tool mode is changed to manipulate
-    Then the mode status shows the tool label "Manipuler"
+    Then the mode status shows the tool label Manipuler
     And the mode status omits the edge mode

--- a/tests/features/gpui_i18n_status.feature
+++ b/tests/features/gpui_i18n_status.feature
@@ -1,0 +1,29 @@
+Feature: Localized Phase 0 shell status
+
+  Scenario: Default English catalogue localizes the mode status
+    Given a fresh Phase 0 shell using the default English catalogue
+    Then the mode status shows the tool label "Draw"
+    And the mode status shows the edge label "Line"
+
+  Scenario: Injected French catalogue localizes the mode status
+    Given a fresh Phase 0 shell using the test French catalogue
+    Then the mode status shows the tool label "Dessiner"
+    And the mode status shows the edge label "Ligne"
+
+  Scenario: Switching locale updates the mode status
+    Given a fresh Phase 0 shell with English and French catalogues
+    Then the mode status shows the tool label "Draw"
+    When the shell locale is switched to French
+    Then the mode status shows the tool label "Dessiner"
+    And the mode status shows the edge label "Ligne"
+
+  Scenario: Missing French message falls back to the default locale
+    Given a fresh Phase 0 shell with a partial French catalogue
+    Then the mode status shows the tool label "Dessiner"
+    And the mode status shows the fallback edge label
+
+  Scenario: Manipulate mode omits the edge mode from the status
+    Given a fresh Phase 0 shell using the test French catalogue
+    When the shell tool mode is changed to manipulate
+    Then the mode status shows the tool label "Manipuler"
+    And the mode status omits the edge mode

--- a/tests/gpui_i18n_module.rs
+++ b/tests/gpui_i18n_module.rs
@@ -176,9 +176,7 @@ fn mode_status_shows_tool_label(
     #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
     label: String,
 ) -> Result<(), TestSupportError> {
-    // The Gherkin step quotes the label; strip the quotes the placeholder
-    // captured (see the same convention in tests/i18n_bdd.rs).
-    status_contains(cx, label.trim_matches('"'), "tool label")
+    status_contains(cx, &label, "tool label")
 }
 
 #[then("the mode status shows the edge label {label}")]
@@ -186,9 +184,7 @@ fn mode_status_shows_edge_label(
     #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
     label: String,
 ) -> Result<(), TestSupportError> {
-    // The Gherkin step quotes the label; strip the quotes the placeholder
-    // captured (see the same convention in tests/i18n_bdd.rs).
-    status_contains(cx, label.trim_matches('"'), "edge label")
+    status_contains(cx, &label, "edge label")
 }
 
 #[then("the mode status shows the fallback edge label")]

--- a/tests/gpui_i18n_module.rs
+++ b/tests/gpui_i18n_module.rs
@@ -212,14 +212,17 @@ fn mode_status_omits_edge_mode(
     #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
 ) -> Result<(), TestSupportError> {
     let status = status_line(cx)?;
-    // Manipulate mode has no edge; the active edge label ("Ligne", the Line
-    // edge mode in the test French catalogue) must therefore be absent.
-    let edge_label = "Ligne";
-    if !status.contains(edge_label) {
+    // Manipulate mode renders the tool-only template with no edge fragment.
+    // Assert the whole status so any spurious edge suffix is rejected in either
+    // locale (e.g. "Mode: Manipuler (Line)" or "(Ligne)"), not just the French
+    // edge label. The French catalogue localizes the tool label to "Manipuler"
+    // and falls back to the en-GB "Mode: {tool}" status template.
+    let expected = "Mode: Manipuler";
+    if status == expected {
         return Ok(());
     }
     Err(TestSupportError::expectation(format!(
-        "expected manipulate mode status to omit the edge label '{edge_label}', got: {status}"
+        "expected manipulate mode status '{expected}' with no edge fragment, got: {status}"
     )))
 }
 

--- a/tests/gpui_i18n_module.rs
+++ b/tests/gpui_i18n_module.rs
@@ -203,11 +203,14 @@ fn mode_status_omits_edge_mode(
     #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
 ) -> Result<(), TestSupportError> {
     let status = status_line(cx)?;
-    if !status.contains('(') && !status.contains(')') {
+    // Manipulate mode has no edge; the active edge label ("Ligne", the Line
+    // edge mode in the test French catalogue) must therefore be absent.
+    let edge_label = "Ligne";
+    if !status.contains(edge_label) {
         return Ok(());
     }
     Err(TestSupportError::expectation(format!(
-        "expected manipulate mode status without an edge-mode fragment, got: {status}"
+        "expected manipulate mode status to omit the edge label '{edge_label}', got: {status}"
     )))
 }
 

--- a/tests/gpui_i18n_module.rs
+++ b/tests/gpui_i18n_module.rs
@@ -4,7 +4,7 @@ mod common;
 
 use std::{cell::RefCell, collections::HashMap};
 
-use common::{init_test_app, test_french_catalog};
+use common::{init_test_app, make_test_catalog, test_french_catalog};
 use gauss::{
     i18n::{Catalog, Locale, Localizer},
     model::ToolMode,
@@ -47,42 +47,34 @@ fn scenario_state_cleanup() -> ScenarioStateCleanup {
     ScenarioStateCleanup
 }
 
-fn setup_localizer() -> Localizer {
-    let mut catalogs = HashMap::new();
-    catalogs.insert(Locale::fr_fr(), test_french_catalog());
-    catalogs.insert(Locale::en_gb(), Catalog::default_en_gb());
+/// Builds the bilingual localizer shape shared by these scenarios: a French and
+/// an English catalogue with en-GB as the default (and therefore fallback)
+/// locale. Keeping the default locale in one place avoids repeating it per
+/// helper.
+fn build_localizer(french: Catalog, english: Catalog) -> Localizer {
+    let catalogs = HashMap::from([(Locale::fr_fr(), french), (Locale::en_gb(), english)]);
     Localizer::with_catalogs(catalogs, Locale::en_gb())
 }
 
+fn setup_localizer() -> Localizer {
+    build_localizer(test_french_catalog(), Catalog::default_en_gb())
+}
+
 fn partial_french_localizer() -> Localizer {
-    let partial_fr_catalog = Catalog::from_messages(HashMap::from([(
-        "tool_mode.draw".to_owned(),
-        "Dessiner".to_owned(),
-    )]));
-    let en_catalog = Catalog::from_messages(HashMap::from([
-        ("tool_mode.draw".to_owned(), "Draw".to_owned()),
-        ("tool_mode.manipulate".to_owned(), "Manipulate".to_owned()),
-        (
-            "edge_mode.line".to_owned(),
-            "Line via en-GB catalogue".to_owned(),
-        ),
-        (
-            "edge_mode.bezier_auto".to_owned(),
-            "Bezier (auto)".to_owned(),
-        ),
-        (
-            "tool.status.mode_with_edge".to_owned(),
-            "Mode: {tool} ({edge})".to_owned(),
-        ),
-        ("tool.status.mode".to_owned(), "Mode: {tool}".to_owned()),
-    ]));
-    Localizer::with_catalogs(
-        HashMap::from([
-            (Locale::fr_fr(), partial_fr_catalog),
-            (Locale::en_gb(), en_catalog),
-        ]),
-        Locale::en_gb(),
-    )
+    // The French catalogue is deliberately incomplete: only `tool_mode.draw` is
+    // present, so every other key must fall back to en-GB. The en-GB catalogue
+    // uses a distinctive `edge_mode.line` marker so the fallback path is
+    // observable in the mode status.
+    let partial_fr_catalog = make_test_catalog(&[("tool_mode.draw", "Dessiner")]);
+    let en_catalog = make_test_catalog(&[
+        ("tool_mode.draw", "Draw"),
+        ("tool_mode.manipulate", "Manipulate"),
+        ("edge_mode.line", "Line via en-GB catalogue"),
+        ("edge_mode.bezier_auto", "Bezier (auto)"),
+        ("tool.status.mode_with_edge", "Mode: {tool} ({edge})"),
+        ("tool.status.mode", "Mode: {tool}"),
+    ]);
+    build_localizer(partial_fr_catalog, en_catalog)
 }
 
 fn assign_shell(cx: &mut TestAppContext, localizer: Localizer, locale: Locale) {
@@ -184,6 +176,8 @@ fn mode_status_shows_tool_label(
     #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
     label: String,
 ) -> Result<(), TestSupportError> {
+    // The Gherkin step quotes the label; strip the quotes the placeholder
+    // captured (see the same convention in tests/i18n_bdd.rs).
     status_contains(cx, label.trim_matches('"'), "tool label")
 }
 
@@ -192,6 +186,8 @@ fn mode_status_shows_edge_label(
     #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
     label: String,
 ) -> Result<(), TestSupportError> {
+    // The Gherkin step quotes the label; strip the quotes the placeholder
+    // captured (see the same convention in tests/i18n_bdd.rs).
     status_contains(cx, label.trim_matches('"'), "edge label")
 }
 

--- a/tests/gpui_i18n_module.rs
+++ b/tests/gpui_i18n_module.rs
@@ -21,6 +21,19 @@ struct ScenarioState {
     shell: Option<Entity<Phase0Shell>>,
 }
 
+// The shell entity is shared across Given/When/Then steps through this
+// `thread_local!` cell rather than an rstest fixture. This is the sanctioned
+// v0.6 interim "stateful GPUI" pattern, not incidental global state: a step
+// that borrows the harness-provided `&mut TestAppContext` cannot also take a
+// second fixture parameter for the shared state, because the generated wrapper
+// would hold a `borrow_ref`/`borrow_mut` pair on the same `StepContext` and
+// rustc rejects it (E0502) — reshaping the fixture to `&T` with interior
+// mutability does not help, since the conflict is on the `StepContext` handle,
+// not the fixture value. See docs/rstest-bdd-users-guide.md ("stateful GPUI
+// scenarios") and the identical pattern in tests/gpui_draw_undo_bdd.rs. The
+// thread-local shape is retired by the rstest-bdd v0.7.0 redesign. Each such
+// scenario is `#[serial]` and resets on both sides (before assigning fresh
+// handles and via a `Drop` guard after the scenario).
 thread_local! {
     static SCENARIO_STATE: RefCell<ScenarioState> = RefCell::new(ScenarioState::default());
 }

--- a/tests/gpui_i18n_module.rs
+++ b/tests/gpui_i18n_module.rs
@@ -1,20 +1,52 @@
-//! GPUI tests for i18n integration with Phase 0 shell.
+//! GPUI behavioural scenarios for localized Phase 0 shell status text.
 
 mod common;
 
-use std::collections::HashMap;
-
-use gpui::{Entity, TestAppContext};
-
-use gauss::i18n::{Catalog, Locale, Localizer};
-use gauss::ui::phase0_shell::Phase0Shell;
+use std::{cell::RefCell, collections::HashMap};
 
 use common::{init_test_app, test_french_catalog};
+use gauss::{
+    i18n::{Catalog, Locale, Localizer},
+    model::ToolMode,
+    ui::phase0_shell::Phase0Shell,
+};
+use gpui::{Entity, TestAppContext};
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use serial_test::serial;
+use test_support::TestSupportError;
 
-/// Build a localizer with French and English (en-GB) catalogues.
-///
-/// Returns a Localizer configured with `test_french_catalog()` and
-/// `Catalog::default_en_gb()`, using `Locale::en_gb()` as the default.
+#[derive(Default)]
+struct ScenarioState {
+    shell: Option<Entity<Phase0Shell>>,
+}
+
+thread_local! {
+    static SCENARIO_STATE: RefCell<ScenarioState> = RefCell::new(ScenarioState::default());
+}
+
+fn with_state<R>(f: impl FnOnce(&mut ScenarioState) -> R) -> R {
+    SCENARIO_STATE.with(|cell| f(&mut cell.borrow_mut()))
+}
+
+fn reset_state() {
+    with_state(|state| *state = ScenarioState::default());
+}
+
+struct ScenarioStateCleanup;
+
+impl Drop for ScenarioStateCleanup {
+    fn drop(&mut self) {
+        reset_state();
+    }
+}
+
+#[fixture]
+fn scenario_state_cleanup() -> ScenarioStateCleanup {
+    reset_state();
+    ScenarioStateCleanup
+}
+
 fn setup_localizer() -> Localizer {
     let mut catalogs = HashMap::new();
     catalogs.insert(Locale::fr_fr(), test_french_catalog());
@@ -22,173 +54,203 @@ fn setup_localizer() -> Localizer {
     Localizer::with_catalogs(catalogs, Locale::en_gb())
 }
 
-/// Create a `Phase0Shell` with the given localizer and locale.
-///
-/// # Preconditions
-///
-/// The caller must call `init_test_app(cx)` before invoking this helper.
-///
-/// Returns the shell entity for test assertions.
-fn setup_shell_with_localizer(
-    cx: &mut TestAppContext,
-    localizer: Localizer,
-    locale: Locale,
-) -> Entity<Phase0Shell> {
+fn partial_french_localizer() -> Localizer {
+    let partial_fr_catalog = Catalog::from_messages(HashMap::from([(
+        "tool_mode.draw".to_owned(),
+        "Dessiner".to_owned(),
+    )]));
+    let en_catalog = Catalog::from_messages(HashMap::from([
+        ("tool_mode.draw".to_owned(), "Draw".to_owned()),
+        ("tool_mode.manipulate".to_owned(), "Manipulate".to_owned()),
+        (
+            "edge_mode.line".to_owned(),
+            "Line via en-GB catalogue".to_owned(),
+        ),
+        (
+            "edge_mode.bezier_auto".to_owned(),
+            "Bezier (auto)".to_owned(),
+        ),
+        (
+            "tool.status.mode_with_edge".to_owned(),
+            "Mode: {tool} ({edge})".to_owned(),
+        ),
+        ("tool.status.mode".to_owned(), "Mode: {tool}".to_owned()),
+    ]));
+    Localizer::with_catalogs(
+        HashMap::from([
+            (Locale::fr_fr(), partial_fr_catalog),
+            (Locale::en_gb(), en_catalog),
+        ]),
+        Locale::en_gb(),
+    )
+}
+
+fn assign_shell(cx: &mut TestAppContext, localizer: Localizer, locale: Locale) {
+    reset_state();
+    init_test_app(cx);
     let (shell, _visual_cx) = cx.add_window_view(|_window, view_cx| {
         let mut shell_instance = Phase0Shell::new(view_cx);
         shell_instance.set_localizer(localizer);
         shell_instance.set_locale(locale);
         shell_instance
     });
-    shell
+    with_state(|state| state.shell = Some(shell));
 }
 
-/// Assert that the mode status line contains every fragment in `expected`.
-///
-/// Initialises the test app, builds a shell with the given localizer and
-/// locale, reads the status line, and panics with a descriptive message if
-/// any fragment is absent.
-fn check_status_labels(
-    cx: &mut TestAppContext,
-    localizer: Localizer,
-    locale: Locale,
-    expected: &[&str],
-) {
-    init_test_app(cx);
-    let shell = setup_shell_with_localizer(cx, localizer, locale);
-    let status = shell.read_with(cx, |s, _cx| s.mode_status_line_for_tests());
-    for fragment in expected {
-        assert!(
-            status.contains(fragment),
-            "Expected '{fragment}' in status line, got: {status}",
-        );
+fn current_shell() -> Result<Entity<Phase0Shell>, TestSupportError> {
+    with_state(|state| state.shell.clone()).ok_or_else(|| {
+        TestSupportError::missing(
+            "Phase 0 shell",
+            "a Given step must assign the shell before it is used",
+        )
+    })
+}
+
+fn status_line(cx: &TestAppContext) -> Result<String, TestSupportError> {
+    let shell_entity = current_shell()?;
+    Ok(shell_entity.read_with(cx, |shell, _cx| shell.mode_status_line_for_tests()))
+}
+
+#[given("a fresh Phase 0 shell using the default English catalogue")]
+fn default_english_shell(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    assign_shell(cx, Localizer::new(), Locale::en_gb());
+    current_shell()?;
+    Ok(())
+}
+
+#[given("a fresh Phase 0 shell using the test French catalogue")]
+fn test_french_shell(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    assign_shell(cx, setup_localizer(), Locale::fr_fr());
+    current_shell()?;
+    Ok(())
+}
+
+#[given("a fresh Phase 0 shell with English and French catalogues")]
+fn bilingual_shell(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    assign_shell(cx, setup_localizer(), Locale::en_gb());
+    current_shell()?;
+    Ok(())
+}
+
+#[given("a fresh Phase 0 shell with a partial French catalogue")]
+fn partial_french_shell(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    assign_shell(cx, partial_french_localizer(), Locale::fr_fr());
+    current_shell()?;
+    Ok(())
+}
+
+#[when("the shell locale is switched to French")]
+fn switch_locale_to_french(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    current_shell()?.update(cx, |shell, _cx| shell.set_locale(Locale::fr_fr()));
+    Ok(())
+}
+
+#[when("the shell tool mode is changed to manipulate")]
+fn switch_to_manipulate(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    current_shell()?.update(cx, |shell, _cx| {
+        shell.set_tool_mode_for_tests(ToolMode::Manipulate);
+    });
+    Ok(())
+}
+
+fn status_contains(
+    cx: &TestAppContext,
+    expected: &str,
+    description: &str,
+) -> Result<(), TestSupportError> {
+    let status = status_line(cx)?;
+    if status.contains(expected) {
+        return Ok(());
     }
+    Err(TestSupportError::expectation(format!(
+        "expected {description} '{expected}' in mode status, got: {status}"
+    )))
 }
 
-#[gpui::test]
-fn phase0_shell_status_uses_default_english_catalog(cx: &mut TestAppContext) {
-    check_status_labels(cx, Localizer::new(), Locale::en_gb(), &["Draw", "Line"]);
+#[then("the mode status shows the tool label {label}")]
+fn mode_status_shows_tool_label(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+    label: String,
+) -> Result<(), TestSupportError> {
+    status_contains(cx, label.trim_matches('"'), "tool label")
 }
 
-#[gpui::test]
-fn phase0_shell_status_uses_injected_test_catalog(cx: &mut TestAppContext) {
-    check_status_labels(
-        cx,
-        setup_localizer(),
-        Locale::fr_fr(),
-        &["Dessiner", "Ligne"],
-    );
+#[then("the mode status shows the edge label {label}")]
+fn mode_status_shows_edge_label(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+    label: String,
+) -> Result<(), TestSupportError> {
+    status_contains(cx, label.trim_matches('"'), "edge label")
 }
 
-#[gpui::test]
-fn locale_switching_updates_status_line(cx: &mut TestAppContext) {
-    init_test_app(cx);
-    let localizer = setup_localizer();
-
-    let (shell, _visual_cx) = cx.add_window_view(|_window, view_cx| {
-        let mut shell_instance = Phase0Shell::new(view_cx);
-        shell_instance.set_localizer(localizer);
-        shell_instance
-    });
-
-    // Verify English default
-    let status_en = shell.read_with(cx, |s, _cx| s.mode_status_line_for_tests());
-    assert!(
-        status_en.contains("Draw"),
-        "Expected English 'Draw' before locale switch, got: {status_en}"
-    );
-
-    // Switch to French
-    shell.update(cx, |s, _cx| {
-        s.set_locale(Locale::fr_fr());
-    });
-
-    // Verify French after switch
-    let status_fr = shell.read_with(cx, |s, _cx| s.mode_status_line_for_tests());
-    assert!(
-        status_fr.contains("Dessiner"),
-        "Expected French 'Dessiner' after locale switch, got: {status_fr}"
-    );
-    assert!(
-        status_fr.contains("Ligne"),
-        "Expected French 'Ligne' after locale switch, got: {status_fr}"
-    );
+#[then("the mode status shows the fallback edge label")]
+fn mode_status_shows_fallback_edge_label(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    status_contains(cx, "Line via en-GB catalogue", "fallback edge label")
 }
 
-#[gpui::test]
-fn fallback_to_default_locale_when_message_missing(cx: &mut TestAppContext) {
-    init_test_app(cx);
-    // Create a French catalogue with only one message (missing the edge mode messages)
-    let mut fr_messages = HashMap::new();
-    fr_messages.insert("tool_mode.draw".to_owned(), "Dessiner".to_owned());
-    let partial_fr_catalog = Catalog::from_messages(fr_messages);
-
-    // Create en-GB catalogue with distinctive sentinel value to prove fallback path
-    let mut en_messages = HashMap::new();
-    en_messages.insert("tool_mode.draw".to_owned(), "Draw".to_owned());
-    en_messages.insert("tool_mode.manipulate".to_owned(), "Manipulate".to_owned());
-    en_messages.insert(
-        "edge_mode.line".to_owned(),
-        "Line via en-GB catalogue".to_owned(),
-    );
-    en_messages.insert(
-        "edge_mode.bezier_auto".to_owned(),
-        "Bezier (auto)".to_owned(),
-    );
-    en_messages.insert(
-        "tool.status.mode_with_edge".to_owned(),
-        "Mode: {tool} ({edge})".to_owned(),
-    );
-    en_messages.insert("tool.status.mode".to_owned(), "Mode: {tool}".to_owned());
-    let en_catalog = Catalog::from_messages(en_messages);
-
-    let mut catalogs = HashMap::new();
-    catalogs.insert(Locale::fr_fr(), partial_fr_catalog);
-    catalogs.insert(Locale::en_gb(), en_catalog);
-    let localizer = Localizer::with_catalogs(catalogs, Locale::en_gb());
-
-    let shell = setup_shell_with_localizer(cx, localizer, Locale::fr_fr());
-
-    let status = shell.read_with(cx, |s, _cx| s.mode_status_line_for_tests());
-
-    // Should have French tool mode
-    assert!(
-        status.contains("Dessiner"),
-        "Expected French 'Dessiner' from partial catalog, got: {status}"
-    );
-
-    // Should fall back to en-GB catalogue for missing edge mode with distinctive sentinel
-    assert!(
-        status.contains("Line via en-GB catalogue"),
-        "Expected en-GB catalogue fallback 'Line via en-GB catalogue' for missing message, got: {status}"
-    );
+#[then("the mode status omits the edge mode")]
+fn mode_status_omits_edge_mode(
+    #[from(rstest_bdd_harness_context)] cx: &mut TestAppContext,
+) -> Result<(), TestSupportError> {
+    let status = status_line(cx)?;
+    if !status.contains('(') && !status.contains(')') {
+        return Ok(());
+    }
+    Err(TestSupportError::expectation(format!(
+        "expected manipulate mode status without an edge-mode fragment, got: {status}"
+    )))
 }
 
-#[gpui::test]
-fn manipulate_mode_omits_edge_mode_in_status_line(cx: &mut TestAppContext) {
-    use gauss::model::ToolMode;
+#[scenario(
+    path = "tests/features/gpui_i18n_status.feature",
+    name = "Default English catalogue localizes the mode status",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+#[serial]
+fn default_english_catalogue(#[from(scenario_state_cleanup)] _cleanup: ScenarioStateCleanup) {}
 
-    init_test_app(cx);
-    let localizer = setup_localizer();
-    let shell = setup_shell_with_localizer(cx, localizer, Locale::fr_fr());
+#[scenario(
+    path = "tests/features/gpui_i18n_status.feature",
+    name = "Injected French catalogue localizes the mode status",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+#[serial]
+fn injected_french_catalogue(#[from(scenario_state_cleanup)] _cleanup: ScenarioStateCleanup) {}
 
-    // Switch to Manipulate mode
-    shell.update(cx, |s, _cx| {
-        s.set_tool_mode_for_tests(ToolMode::Manipulate);
-    });
+#[scenario(
+    path = "tests/features/gpui_i18n_status.feature",
+    name = "Switching locale updates the mode status",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+#[serial]
+fn switching_locale(#[from(scenario_state_cleanup)] _cleanup: ScenarioStateCleanup) {}
 
-    let status = shell.read_with(cx, |s, _cx| s.mode_status_line_for_tests());
+#[scenario(
+    path = "tests/features/gpui_i18n_status.feature",
+    name = "Missing French message falls back to the default locale",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+#[serial]
+fn missing_french_message(#[from(scenario_state_cleanup)] _cleanup: ScenarioStateCleanup) {}
 
-    // Should contain localized tool mode
-    assert!(
-        status.contains("Manipuler"),
-        "Expected French 'Manipuler' for Manipulate mode, got: {status}"
-    );
-
-    // Should NOT contain edge mode wrapper pattern "({edge})" from
-    // tool.status.mode_with_edge template
-    assert!(
-        !status.contains('(') && !status.contains(')'),
-        "Manipulate mode should omit edge mode fragment entirely (no parentheses), got: {status}"
-    );
-}
+#[scenario(
+    path = "tests/features/gpui_i18n_status.feature",
+    name = "Manipulate mode omits the edge mode from the status",
+    harness = rstest_bdd_harness_gpui::GpuiHarness,
+)]
+#[serial]
+fn manipulate_mode_status(#[from(scenario_state_cleanup)] _cleanup: ScenarioStateCleanup) {}


### PR DESCRIPTION
## Summary

This branch migrates the Phase 0 shell localization behaviours from raw `#[gpui::test]` functions to Gherkin scenarios driven by the rstest-bdd GPUI harness. It completes the behavioural portion of issue #120 while retaining the widget-audit seam tests unchanged because they are ordinary structural inventory audits and do not exercise GPUI behaviour.

Closes #120.

## Review walkthrough

- Start with [the localized status feature](https://github.com/leynos/gauss/blob/d1b9f3d/tests/features/gpui_i18n_status.feature) to review the five observable localization behaviours.
- Then review [the GPUI i18n scenario bindings and steps](https://github.com/leynos/gauss/blob/d1b9f3d/tests/gpui_i18n_module.rs) for the durable entity state, fallible steps and `GpuiHarness` bindings.
- The existing [widget-audit shell seam](https://github.com/leynos/gauss/blob/d1b9f3d/tests/gpui_widget_audit_shell_seam.rs) remains structural and is deliberately not converted to BDD.

## Validation

- Deliberate assertion break: failed at `Then the mode status shows the fallback edge label`, as expected.
- `make check-fmt`: passed.
- `make lint`: passed, including Rustdoc, Clippy with warnings denied and Whitaker.
- `make test`: passed; 909 tests passed and 1 was skipped across 68 binaries.
- `coderabbit review --agent`: passed with 0 findings.

## Notes

This pull request targets `adopt-rstest-bdd-v0-6-0-beta3` so it can be reviewed and merged independently on top of PR #113.

## Summary by Sourcery

Migrate Phase 0 shell i18n status tests from imperative gpui tests to BDD scenarios using the rstest-bdd GPUI harness.

Tests:
- Replace existing GPUI i18n status tests with Gherkin-based scenarios and step bindings that exercise localized mode status behaviour, locale switching, and catalogue fallback.
- Introduce shared GPUI test scenario state management and helpers to support the new BDD-style i18n tests.

## References

- [Lody session](https://lody.ai/leynos/sessions/4a158bc5-1617-4d63-85e2-e0d82285c307)
