### PR TITLE
Wire the CodeScene mode: check gate into the PR coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,15 @@ jobs:
           output-path: lcov.info
           format: lcov
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 75146 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro's projects hit the byte-identical
-      # error). Add the check step in a fast-follow PR once
-      # coverage-main.yml has uploaded to main at least once and the
-      # gate is confirmed to resolve, or once CodeScene confirms the
-      # project's coverage gate is enabled.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: >-
+          leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/75146
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- Replace the deferred-gate comment in `ci.yml`'s `build-test` job with
  the real `mode: check` step, now that CodeScene project 75146's
  coverage-gates configuration is populated (previously it returned an
  empty config and every `cs-coverage check` run failed with "Lacks
  the gates configuration").
- Guarded identically to the existing upload step: only runs when
  `CS_ACCESS_TOKEN` is set and the trigger is `pull_request`, so
  token-less or `workflow_dispatch` runs skip it rather than fail.
- Pin (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`) and `format: lcov`
  match the repo's existing `generate-coverage` / `upload-codescene-coverage`
  usage in both `ci.yml` and `coverage-main.yml` — no new pin
  introduced.
- `coverage-main.yml` is untouched; it keeps `mode: upload` on push to
  `main`.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/gauss/blob/codescene-mode-check/.github/workflows/ci.yml) —
  new "Check coverage against CodeScene gates" step after "Test and
  Measure Coverage", replacing the placeholder comment block.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- No workflow-contract tests exist in this repo that pin `ci.yml`'s
  structure.
- `fetch-depth: 0` was already in place on the `build-test` job's
  checkout step (required for `cs-coverage check` to reach the merge
  base).
- Confirmed via `GET /v2/code-coverage/projects/75146/config` that the
  project now returns a populated `gates` array rather than an empty
  200.
