### PR TITLE
Document GPUI test-helper consumers (#150)

### DIFF
--- a/tests/common/durable_shell.rs
+++ b/tests/common/durable_shell.rs
@@ -1,7 +1,16 @@
 //! Durable GPUI handles that survive between BDD scenario steps.
 //!
-//! Every `gpui_file_io_*` scenario binary includes this module, and each uses all
-//! of it, so nothing here needs a `dead_code` expectation.
+//! This module is included by `gpui_file_io_click_save_button`,
+//! `gpui_file_io_metadata_round_trip`, `gpui_file_io_open_dialog`,
+//! `gpui_file_io_save_dialog`, `gpui_selection_bbox_drag_requires_selection`,
+//! `gpui_selection_clear_selection`, `gpui_selection_multi_select`,
+//! `gpui_selection_multi_shape_drag`, `gpui_selection_select_shape_by_bbox`,
+//! and `gpui_selection_select_tool_noop_paths`; selection binaries include it
+//! transitively through `tests/selection_bdd/support.rs`.
+//!
+//! `DurableShell::new` and `with_visual_cx` are used by all ten consumers. The
+//! remaining file-I/O binaries read `entity` directly in their own crate, so no
+//! `dead_code` expectation is needed.
 
 use gauss::ui::Phase0Shell;
 use gpui::{AnyWindowHandle, Entity, TestAppContext, VisualContext, VisualTestContext};


### PR DESCRIPTION
## Summary

This branch confirms that the topic-module split required by #150 is already
present, and corrects the stale `DurableShell` module documentation so it names
its complete consumer set and accurately describes field use.

Closes #150.

## Review walkthrough

- Start with [tests/common/durable_shell.rs](https://github.com/leynos/gauss/blob/issue-150-eliminate-the-residual-dead-code-expectation-in-the-shared-gpui-test-helpers/tests/common/durable_shell.rs#L1), which records all four file-I/O and six selection consumers, including the latter's transitive inclusion path.
- The branch intentionally changes no helper behaviour: the already-merged split
  keeps each topic module scoped to consuming integration-test crates, preserving
  compiler detection of genuinely dead helpers.

## Validation

- `make lint` — passed with no `dead_code`, `unused_imports`, or
  `unfulfilled_lint_expectations` warnings.
- `make all` — passed: 950 tests passed, 1 skipped; doctests and Python checks
  passed.
- `coderabbit review --agent` — completed with 0 findings.

## References

- [Lody session](https://lody.ai/leynos/sessions/e20c0899-c288-41a7-ac67-46c119eebaa7)

## Summary by Sourcery

Clarify DurableShell test-helper usage so dead-code expectations remain accurately documented without changing helper behavior.

Enhancements:
- Update DurableShell module documentation to enumerate all file-I/O and selection test consumers and accurately describe shared versus direct field usage.

Documentation:
- Document the complete set of GPUI test-helper consumers and their inclusion path.